### PR TITLE
Update python_ex226.py

### DIFF
--- a/python_ex226.py
+++ b/python_ex226.py
@@ -1,2 +1,2 @@
 # code in module2
-import hello
+import module1


### PR DESCRIPTION
pg 120 in the self-taught programmer. Should import "module1" (instead of "hello") according to instructions and for reproducing the autorun error with imported modules.  Importing "hello" does not produce the same error mentioned in the example.