### PR TITLE
Update python_ex228.py

### DIFF
--- a/python_ex228.py
+++ b/python_ex228.py
@@ -1,3 +1,3 @@
 
 # code in module2
-import hello
+import module1


### PR DESCRIPTION
pg 121 in the self-taught programmer. Should import "module1" (instead of "hello") according to instructions and for reproducing the autorun error with imported modules. Importing "hello" does not produce the same error mentioned in the prior example (see previous pull request), therefore to resolve the error, will also need to call "module1" in this example.